### PR TITLE
Add public repository guidance and copyright headers

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,10 @@
+# Microsoft Open Source Code of Conduct
+
+This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
+
+Resources:
+
+- [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/)
+- [Microsoft Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/)
+- Contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with questions or concerns
+- Employees can reach out at [aka.ms/opensource/moderation-support](https://aka.ms/opensource/moderation-support)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,32 @@
+# Contributing
+
+This project welcomes contributions and suggestions. Most contributions require you to
+agree to a Contributor License Agreement (CLA) declaring that you have the right to,
+and actually do, grant us the rights to use your contribution. For details, visit
+https://cla.microsoft.com.
+
+When you submit a pull request, a CLA-bot will automatically determine whether you need
+to provide a CLA and decorate the PR appropriately (for example, label or comment).
+Simply follow the instructions provided by the bot. You will only need to do this once
+across all repositories using our CLA.
+
+This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
+For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/)
+or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
+
+## Reporting security issues
+
+Please do not report security vulnerabilities through public GitHub issues. Follow the instructions in [SECURITY.md](SECURITY.md).
+
+## Development workflow
+
+Before opening a pull request, run the checks relevant to your change:
+
+```bash
+source .venv/bin/activate
+maturin develop
+cargo clippy --all-targets
+pytest -v
+```
+
+After Rust source changes (`src/*.rs`), re-run `maturin develop` before running Python tests.

--- a/README.md
+++ b/README.md
@@ -295,6 +295,26 @@ See [CHANGELOG.md](https://github.com/microsoft/duroxide-python/blob/main/CHANGE
 - [User Guide](https://github.com/microsoft/duroxide-python/blob/main/docs/user-guide.md) — orchestration patterns, activities, providers, tracing, determinism rules
 - [Architecture](https://github.com/microsoft/duroxide-python/blob/main/docs/architecture.md) — PyO3 interop, GIL deadlock fix, generator driver, tracing internals
 
+## Support
+
+Use GitHub Issues for bug reports and feature requests. Do not report security vulnerabilities through public GitHub issues; follow the instructions in [SECURITY.md](SECURITY.md) instead.
+
+## Code of Conduct
+
+This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information, see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with questions or comments.
+
+## Security
+
+Microsoft takes the security of our software products and services seriously. Please do not report security vulnerabilities through public GitHub issues. See [SECURITY.md](SECURITY.md) for security reporting instructions.
+
+## Privacy and Telemetry
+
+duroxide-python does not send telemetry to Microsoft. Applications may configure their own logging or metrics exporters; those signals are controlled by the application owner.
+
+## Trademarks
+
+This project may contain trademarks or logos for projects, products, or services. Authorized use of Microsoft trademarks or logos is subject to and must follow [Microsoft's Trademark & Brand Guidelines](https://www.microsoft.com/en-us/legal/intellectualproperty/trademarks/usage/general). Use of Microsoft trademarks or logos in modified versions of this project must not cause confusion or imply Microsoft sponsorship. Any use of third-party trademarks or logos is subject to those third-party policies.
+
 ## License
 
-MIT
+MIT License - see [LICENSE](LICENSE) for details.

--- a/ci/smoke/run-local.ps1
+++ b/ci/smoke/run-local.ps1
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 # Pre-publish smoke for Windows. See run-local.sh for details.
 $ErrorActionPreference = 'Stop'
 

--- a/ci/smoke/run-local.sh
+++ b/ci/smoke/run-local.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 # Pre-publish smoke: install the duroxide wheel for the current platform into
 # a fresh venv OUTSIDE the repo, then run smoke.py.
 #

--- a/ci/smoke/run-registry.ps1
+++ b/ci/smoke/run-registry.ps1
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 # Post-publish smoke for Windows. See run-registry.sh for details.
 $ErrorActionPreference = 'Stop'
 

--- a/ci/smoke/run-registry.sh
+++ b/ci/smoke/run-registry.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 # Post-publish smoke: install `duroxide==<version>` from PyPI into a fresh
 # venv and run smoke.py.
 #

--- a/ci/smoke/smoke.py
+++ b/ci/smoke/smoke.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """
 Cross-platform packaging smoke test for the `duroxide` PyPI wheel.
 

--- a/python/duroxide/__init__.py
+++ b/python/duroxide/__init__.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """
 duroxide - Python SDK for the Duroxide durable execution runtime.
 

--- a/python/duroxide/context.py
+++ b/python/duroxide/context.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """
 OrchestrationContext and ActivityContext for duroxide Python SDK.
 

--- a/python/duroxide/driver.py
+++ b/python/duroxide/driver.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """
 Generator driver for duroxide Python SDK.
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 use pyo3::prelude::*;
 use std::sync::Arc;
 use std::time::Duration;

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 use parking_lot::Mutex;
 use pyo3::prelude::*;
 use std::collections::HashMap;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 mod client;
 mod handlers;
 mod pg_provider;

--- a/src/pg_provider.rs
+++ b/src/pg_provider.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 use pyo3::prelude::*;
 use std::sync::Arc;
 use std::time::Duration;

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 use pyo3::prelude::*;
 use std::sync::Arc;
 

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 use pyo3::prelude::*;
 use std::sync::Arc;
 use std::time::Duration;

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 use pyo3::prelude::*;
 use serde::{Deserialize, Serialize};
 

--- a/tests/scenarios/__init__.py
+++ b/tests/scenarios/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.

--- a/tests/scenarios/test_toygres.py
+++ b/tests/scenarios/test_toygres.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """
 Toygres Scenario Tests — duroxide Python SDK
 

--- a/tests/test_admin_api.py
+++ b/tests/test_admin_api.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """
 Management / Admin API tests for duroxide Python SDK — PostgreSQL backend.
 

--- a/tests/test_advanced_features.py
+++ b/tests/test_advanced_features.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """
 Advanced feature tests covering typed registration, retry, cancellation,
 timers, custom status, event queues, CAN, versioning, errors, and nondeterminism.

--- a/tests/test_async_blocks.py
+++ b/tests/test_async_blocks.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """
 Tests for async blocks using sub-orchestrations with all() and race().
 

--- a/tests/test_copilot_chat.py
+++ b/tests/test_copilot_chat.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """
 Copilot Chat scenario — exercises event queues, custom status, continue-as-new,
 and wait_for_status_change in a multi-turn conversational pattern.

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """
 End-to-end tests for duroxide Python SDK — PostgreSQL backend.
 Ported from duroxide-node/__tests__/e2e.test.js

--- a/tests/test_init_tracing.py
+++ b/tests/test_init_tracing.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """
 Tests for init_tracing function.
 """

--- a/tests/test_kv_store.py
+++ b/tests/test_kv_store.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """End-to-end KV store tests for the duroxide Python SDK."""
 
 import time

--- a/tests/test_races.py
+++ b/tests/test_races.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """
 Tests for ctx.all() (join) and ctx.race() (select) with mixed task types,
 including activity cooperative cancellation via is_cancelled().

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """
 End-to-end tests for activity session affinity in duroxide Python SDK.
 

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """
 Activity tag routing tests for duroxide Python SDK.
 

--- a/tests/test_typed_apis.py
+++ b/tests/test_typed_apis.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """
 Tests for typed convenience API methods in duroxide Python SDK.
 


### PR DESCRIPTION
## Summary
- add Microsoft Open Source Code of Conduct file
- refresh contribution guidance with CLA, security reporting, and project checks
- add README sections for support, code of conduct, security, privacy/telemetry, trademarks, and license
- add Microsoft MIT copyright headers to supported source, script, and SQL files

## Validation
- git diff --check
- verified copyright header coverage for tracked .rs, .js, .ts, .mjs, .py, .sh, .ps1, .sql, and Makefile files
- verified shebang scripts keep the shebang on line 1